### PR TITLE
Fix for #154. Removed incorrect call to ToUniversalTime()

### DIFF
--- a/Snowflake.Data/Core/SFDataConverter.cs
+++ b/Snowflake.Data/Core/SFDataConverter.cs
@@ -205,8 +205,7 @@ namespace Snowflake.Data.Core
                     }
                     else
                     {
-                        long millis = (long)((DateTime)srcVal).ToUniversalTime().Subtract(
-                            UnixEpoch).TotalMilliseconds;
+                        long millis = (long)((DateTime)srcVal).Subtract(UnixEpoch).TotalMilliseconds;
                         destVal = millis.ToString();
                     }
                     break;


### PR DESCRIPTION
Note that this might cause backward compatibility problems. It is possible that someone has noted this problem and added compensating code in the client.
Note that this is only a problem for users where the client is after GMT such as Stockholm or Helsinki